### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
-  skip_before_action :authenticate_user!, only: [:index]
+  before_action :authenticate_user!, except: [:show, :index]
+  before_action :move_to_index, only: [:edit, :update]
+
 
 
   def index
@@ -29,7 +30,25 @@ def show
 
 end
 
+def update
+  @item = Item.find(params[:id]) 
+  if @item.update(item_params)
+    redirect_to item_path(@item)
+  else
+    render :edit,status: :unprocessable_entity
+  end
+end
 
+
+def edit
+  @item = Item.find(params[:id])
+end
+  #if current_user == @item.user && !Order.exists?(item_id: @item.id)
+  #render :edit
+  #else
+  #redirect_to root_path
+  #end
+  #end
 
 
 private
@@ -43,7 +62,12 @@ private
 #def sold_out?
   #!sold_out？ # これは sold_out フラグが nil でないかどうかを確認するものです
 #end
-
+def move_to_index
+  item = Item.find(params[:id])
+  if current_user.id != item.user.id
+    redirect_to root_path
+  end
+end
 
 def item_params
   params.require(:item).permit(:name, :item_image, :description, :price, :condition_id, :category_id, :shipping_fee_id, :prefecture_id, :shipping_date_id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:show, :index]
   before_action :move_to_index, only: [:edit, :update]
+  before_action :set_item, only: [:edit, :show, :update ]
 
 
 
@@ -26,12 +27,11 @@ def create
 end
 
 def show
-  @item = Item.find(params[:id])
-
+  
 end
 
 def update
-  @item = Item.find(params[:id]) 
+  
   if @item.update(item_params)
     redirect_to item_path(@item)
   else
@@ -41,7 +41,7 @@ end
 
 
 def edit
-  @item = Item.find(params[:id])
+  
 end
   #if current_user == @item.user && !Order.exists?(item_id: @item.id)
   #render :edit
@@ -53,6 +53,9 @@ end
 
 private
 
+def set_item
+  @item = Item.find(params[:id])
+end
 
 #def shipping_fee
   # shipping_fee メソッドの定義

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,10 +7,7 @@
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -139,7 +136,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to '商品詳細', root_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -8,7 +8,7 @@
     <%= form_with model: @item, local: true do |f| %>
 
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <% render 'shared/error_messages', model: @item %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
@@ -71,7 +71,7 @@
       配送料の負担
       <span class="indispensable">必須</span>
     </div>
-    <%= f.collection_select(:shipping_fee_id, ShippingFeeStatus.all, :id, :name, { prompt: '---' }, { class: "select-box", id: "item-shipping-fee-status" }) %>
+    <%= f.collection_select(:shipping_fee_id, ShippingFee.all, :id, :name, { prompt: '---' }, { class: "select-box", id: "item-shipping-fee-status" }) %>
     <div class="weight-bold-text">
       発送元の地域
       <span class="indispensable">必須</span>
@@ -81,7 +81,7 @@
       発送までの日数
       <span class="indispensable">必須</span>
     </div>
-    <%= f.collection_select(:shipping_date_id, ScheduledDelivery.all, :id, :name, { prompt: '---' }, { class: "select-box", id: "item-scheduled-delivery" }) %>
+    <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, { prompt: '---' }, { class: "select-box", id: "item-scheduled-delivery" }) %>
   </div>
 </div>
 <%# /配送について %>
@@ -99,7 +99,7 @@
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :item_price, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -136,7 +136,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to '商品詳細', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id) , class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
 <% if @item.user == current_user  %>
 
 
-  <%= link_to "商品の編集", "#", class: "item-red-btn" %>
+  <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
   <p class="or-text">or</p>
   <%= link_to "削除", "#", method: :delete, class: "item-destroy" %>
   <% else%> 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,9 @@
-<% if @item&.errors&.any? %>
-  <div class="error-alert">
-    <ul>
-      <% @item.errors.full_messages.each do |message| %>
-        <li class='error-message'><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
+<% if model.errors.any? %>
+<div class="error-alert">
+  <ul>
+    <% model.errors.full_messages.each do |message| %>
+    <li class='error-message'><%= message %></li>
+    <% end %>
+  </ul>
+</div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,7 @@
 Rails.application.routes.draw do
    devise_for :users
    root to: 'items#index'
-   resources :items, only: [:index, :show, :new, :create, :edit] # :editアクションを追加する
-
+   resources :items
   
    devise_scope :user do
      get '/users/sign_out' => 'devise/sessions#destroy'


### PR DESCRIPTION
Why フリマアプリ作成の為
What  商品情報編集機能の実装

ログイン状態の出品者は、商品情報編集ページに遷移できる動画

https://gyazo.com/56b43160d83c65ac14274e234c718b05

 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画

https://gyazo.com/7adb3075eba5fb5ed665709434ddca78

 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画

https://gyazo.com/7ff0927cdad5f482ecfaec95a529f117

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画

https://gyazo.com/9361daf20ea8d3c33f846c62ba3ff85d

 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画

https://gyazo.com/49c8a5666a92d2f719423ff0c4635720

 ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画

https://gyazo.com/8e89150caf9638c471525954d1191d86


 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）

https://gyazo.com/280758aaf7c9e5dfec2ab19c0b9c26ed